### PR TITLE
Support string escapes parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
+    testCompile 'com.fasterxml.jackson.core:jackson-core:2.8.4'
     testCompile 'com.fasterxml.jackson.core:jackson-databind:2.8.4'
     testCompile 'commons-io:commons-io:2.5'
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    testCompile 'com.fasterxml.jackson.core:jackson-core:2.8.4'
     testCompile 'com.fasterxml.jackson.core:jackson-databind:2.8.4'
     testCompile 'commons-io:commons-io:2.5'
     testCompile 'junit:junit:4.12'

--- a/src/main/java/de/undercouch/actson/JsonParser.java
+++ b/src/main/java/de/undercouch/actson/JsonParser.java
@@ -406,8 +406,8 @@ public class JsonParser {
     } else if (nextState == XU) {
       // End of UTF code point escape
       currentValue.append(nextChar);
-      final int len = currentValue.length();
-      final int code = Integer.parseInt(currentValue.substring(len - 4, len), 16);
+      int len = currentValue.length();
+      int code = Integer.parseInt(currentValue.substring(len - 4, len), 16);
       currentValue.delete(len - 6, len).appendCodePoint(code);
       state = ST;
     } else if (nextState == XE) {

--- a/src/main/java/de/undercouch/actson/JsonParser.java
+++ b/src/main/java/de/undercouch/actson/JsonParser.java
@@ -402,21 +402,11 @@ public class JsonParser {
         event1 = stateToEvent();
       }
 
+      // Change the state.
       state = nextState;
-    } else if (nextState == XU) {
-      // End of UTF code point escape
-      currentValue.append(nextChar);
-      int len = currentValue.length();
-      int code = Integer.parseInt(currentValue.substring(len - 4, len), 16);
-      currentValue.delete(len - 6, len).appendCodePoint(code);
-      state = ST;
-    } else if (nextState == XE) {
-      // End of single byte escape
-      currentValue.setCharAt(currentValue.length() - 1, singleEscapeChar(nextChar));
-      state = ST;
     } else {
       // Or perform one of the actions.
-      performAction(nextState);
+      performAction(nextState, nextChar);
     }
   }
 
@@ -440,7 +430,7 @@ public class JsonParser {
    * Perform an action that changes the parser state
    * @param action the action to perform
    */
-  private void performAction(byte action) {
+  private void performAction(byte action, char nextChar) {
     switch (action) {
     // empty }
     case -9:
@@ -543,6 +533,21 @@ public class JsonParser {
         return;
       }
       state = VA;
+      break;
+
+    // End of UTF code point escape
+    case XU:
+      currentValue.append(nextChar);
+      int len = currentValue.length();
+      int code = Integer.parseInt(currentValue.substring(len - 4, len), 16);
+      currentValue.delete(len - 6, len).appendCodePoint(code);
+      state = ST;
+      break;
+
+    // End of single byte escape
+    case XE:
+      currentValue.setCharAt(currentValue.length() - 1, singleEscapeChar(nextChar));
+      state = ST;
       break;
 
     // Bad action.

--- a/src/test/java/de/undercouch/actson/JsonHelper.java
+++ b/src/test/java/de/undercouch/actson/JsonHelper.java
@@ -1,0 +1,96 @@
+package de.undercouch.actson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class JsonHelper {
+  public static JsonGenerator defaultGenerator(Writer writer) {
+    try {
+      return new JsonFactory().createGenerator(writer);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static JsonGenerator setPrettyPrint(JsonGenerator generator) {
+    return generator.setPrettyPrinter(new DefaultPrettyPrinter());
+  }
+
+  /**
+   * Parse input JSON byte array with Actson and generate JSON text again with Jackson.
+   * Is intended for demonstration and tests.
+   */
+  public static void regenerateJson(final byte[] sourceJson, JsonParser parser, JsonGenerator generator) {
+    try {
+      int i = 0;
+      int event;
+      do {
+        while ((event = parser.nextEvent()) == JsonEvent.NEED_MORE_INPUT) {
+          i += parser.getFeeder().feed(sourceJson, i, sourceJson.length - i);
+          if (i == sourceJson.length) {
+            parser.getFeeder().done();
+          }
+        }
+        eventToGenerator(event, parser, generator);
+      } while (event != JsonEvent.EOF);
+      generator.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * To be called on JSON event to generate JSON text.
+   *
+   * @param event     the JSON event returned by the parser
+   * @param parser    the JSON parser
+   * @param generator send the event to this JSON text generator
+   */
+  public static void eventToGenerator(int event, JsonParser parser, JsonGenerator generator) throws IOException {
+    switch (event) {
+      case JsonEvent.START_OBJECT:
+        generator.writeStartObject();
+        break;
+      case JsonEvent.END_OBJECT:
+        generator.writeEndObject();
+        break;
+      case JsonEvent.START_ARRAY:
+        generator.writeStartArray();
+        break;
+      case JsonEvent.END_ARRAY:
+        generator.writeEndArray();
+        break;
+      case JsonEvent.FIELD_NAME:
+        generator.writeFieldName(parser.getCurrentString());
+        break;
+      case JsonEvent.VALUE_STRING:
+        generator.writeString(parser.getCurrentString());
+        break;
+      case JsonEvent.VALUE_INT:
+        generator.writeNumber(parser.getCurrentInt());
+        break;
+      case JsonEvent.VALUE_DOUBLE:
+        generator.writeNumber(parser.getCurrentDouble());
+        break;
+      case JsonEvent.VALUE_TRUE:
+        generator.writeBoolean(true);
+        break;
+      case JsonEvent.VALUE_FALSE:
+        generator.writeBoolean(false);
+        break;
+      case JsonEvent.VALUE_NULL:
+        generator.writeNull();
+        break;
+      case JsonEvent.EOF:
+        break;
+      case JsonEvent.ERROR:
+        throw new IllegalArgumentException("JSON syntax error.");
+      default:
+        throw new IllegalArgumentException("Unknown event: " + event);
+    }
+  }
+}

--- a/src/test/java/de/undercouch/actson/JsonParserTest.java
+++ b/src/test/java/de/undercouch/actson/JsonParserTest.java
@@ -180,17 +180,28 @@ public class JsonParserTest {
     assertJsonObjectEquals(json, parse(json));
   }
 
+  /**
+   * Test that single UTF code point escape is replaced with actual
+   * code point value in parsed string.
+   */
   @Test
   public void utf8Codepoint() {
     assertEquals("\"\u2615\"", parse("\"\\u2615\""));
   }
 
+  /**
+   * Test that single character escapes are replaced with their
+   * values in parsed string.
+   */
   @Test
   public void escapes() {
     assertEquals("\"\\\" \\\\%22\\\"\"", parse("\"\\u0022 \\\\%22\\\"\""));
     assertEquals("\"\\b\\f\\n\\r\\t/\\\\\"", parse("\"\\b\\f\\n\\r\\t\\/\\\\\""));
   }
 
+  /**
+   * Test that unknown escape symbol is rejected.
+   */
   @Test
   public void invalidEscape() {
     try {
@@ -200,7 +211,6 @@ public class JsonParserTest {
       // Expected
     }
   }
-
 
   /**
    * Test if an object with one property is parsed correctly

--- a/src/test/java/de/undercouch/actson/JsonParserTest.java
+++ b/src/test/java/de/undercouch/actson/JsonParserTest.java
@@ -25,13 +25,17 @@ package de.undercouch.actson;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -64,24 +68,11 @@ public class JsonParserTest {
    * @return the new JSON string
    */
   private String parse(String json, JsonParser parser) {
-    byte[] buf = json.getBytes(StandardCharsets.UTF_8);
-
-    PrettyPrinter printer = new PrettyPrinter();
-
-    int i = 0;
-    int event;
-    do {
-      while ((event = parser.nextEvent()) == JsonEvent.NEED_MORE_INPUT) {
-        i += parser.getFeeder().feed(buf, i, buf.length - i);
-        if (i == buf.length) {
-          parser.getFeeder().done();
-        }
-      }
-      assertFalse("Invalid JSON text", event == JsonEvent.ERROR);
-      printer.onEvent(event, parser);
-    } while (event != JsonEvent.EOF);
-
-    return printer.getResult();
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final JsonGenerator generator = JsonHelper.defaultGenerator(new OutputStreamWriter(out));
+    JsonHelper.setPrettyPrint(generator);
+    JsonHelper.regenerateJson(json.getBytes(StandardCharsets.UTF_8), parser, generator);
+    return out.toString();
   }
 
   /**
@@ -188,6 +179,28 @@ public class JsonParserTest {
     String json = "{}";
     assertJsonObjectEquals(json, parse(json));
   }
+
+  @Test
+  public void utf8Codepoint() {
+    assertEquals("\"\u2615\"", parse("\"\\u2615\""));
+  }
+
+  @Test
+  public void escapes() {
+    assertEquals("\"\\\" \\\\%22\\\"\"", parse("\"\\u0022 \\\\%22\\\"\""));
+    assertEquals("\"\\b\\f\\n\\r\\t/\\\\\"", parse("\"\\b\\f\\n\\r\\t\\/\\\\\""));
+  }
+
+  @Test
+  public void invalidEscape() {
+    try {
+      parse("\"\\z\"");
+      fail("The input should not be accepted.");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
 
   /**
    * Test if an object with one property is parsed correctly

--- a/src/test/java/de/undercouch/actson/PrettyPrinter.java
+++ b/src/test/java/de/undercouch/actson/PrettyPrinter.java
@@ -23,11 +23,12 @@
 
 package de.undercouch.actson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-
-import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import de.undercouch.actson.JsonEvent;
+import de.undercouch.actson.JsonParser;
 
 /**
  * Demonstrates how you can use the {@link JsonParser} to pretty-print
@@ -41,17 +42,176 @@ public class PrettyPrinter {
    * Main method demonstrating how to use the pretty-printer
    * @param args program arguments
    */
-  public static void main(String[] args) throws IOException {
-    byte[] json = "{\"name\":\"Elvis \\u266b\"}".getBytes(StandardCharsets.UTF_8);
+  public static void main(String[] args) {
+    byte[] json =  "{\"name\":\"Elvis \\u266b\"}".getBytes(StandardCharsets.UTF_8);
 
     JsonParser parser = new JsonParser();
+    PrettyPrinter prettyPrinter = new PrettyPrinter();
 
-    final JsonGenerator generator = JsonHelper.defaultGenerator(new OutputStreamWriter(System.out));
-    JsonHelper.setPrettyPrint(generator);
-    JsonHelper.regenerateJson(json, parser, generator);
+    int i = 0;
+    int event;
+    do {
+      while ((event = parser.nextEvent()) == JsonEvent.NEED_MORE_INPUT) {
+        i += parser.getFeeder().feed(json, i, json.length - i);
+        if (i == json.length) {
+          parser.getFeeder().done();
+        }
+      }
+      prettyPrinter.onEvent(event, parser);
+    } while (event != JsonEvent.EOF);
+
+    System.out.println(prettyPrinter.getResult());
     // expected output:
     // {
-    //   "name: "Elvis ♫"
+    //   "name: "Elvis"
     // }
+  }
+
+  private static enum Type {
+    OBJECT, ARRAY
+  }
+
+  private StringBuilder result = new StringBuilder();
+  private Deque<Type> types = new ArrayDeque<>();
+  private Deque<Integer> elementCounts = new ArrayDeque<>();
+  private int level;
+
+  private void indent() {
+    for (int i = 0; i < level; ++i) {
+      result.append("  ");
+    }
+  }
+
+  private void onStartObject() {
+    onValue();
+    result.append("{\n");
+    level++;
+    indent();
+    elementCounts.push(0);
+    types.push(Type.OBJECT);
+  }
+
+  private void onEndObject() {
+    level--;
+    result.append("\n");
+    indent();
+    result.append("}");
+    elementCounts.pop();
+    types.pop();
+  }
+
+  private void onStartArray() {
+    onValue();
+    result.append("[\n");
+    level++;
+    indent();
+    elementCounts.push(0);
+    types.push(Type.ARRAY);
+  }
+
+  private void onEndArray() {
+    level--;
+    result.append("\n");
+    indent();
+    result.append("]");
+    elementCounts.pop();
+    types.pop();
+  }
+
+  private void onFieldName(String name) {
+    if (elementCounts.peek() > 0) {
+      result.append(",\n");
+      indent();
+    }
+    result.append("\"" + name + "\": ");
+    elementCounts.push(elementCounts.pop() + 1);
+  }
+
+  private void onValue() {
+    if (types.peek() == Type.ARRAY) {
+      if (elementCounts.peek() > 0) {
+        result.append(", ");
+      }
+      elementCounts.push(elementCounts.pop() + 1);
+    }
+  }
+
+  private void onValue(String value) {
+    onValue();
+    result.append("\"" + value + "\"");
+  }
+
+  private void onValue(int value) {
+    onValue();
+    result.append(value);
+  }
+
+  private void onValue(double value) {
+    onValue();
+    result.append(value);
+  }
+
+  private void onValue(boolean value) {
+    onValue();
+    result.append(value);
+  }
+
+  private void onValueNull() {
+    onValue();
+    result.append("null");
+  }
+
+  /**
+   * Call this method on every JSON event. It will generate pretty JSON text.
+   * @param event the JSON event returned by the parser
+   * @param parser the JSON parser
+   */
+  public void onEvent(int event, JsonParser parser) {
+    switch (event) {
+    case JsonEvent.START_OBJECT:
+      onStartObject();
+      break;
+    case JsonEvent.END_OBJECT:
+      onEndObject();
+      break;
+    case JsonEvent.START_ARRAY:
+      onStartArray();
+      break;
+    case JsonEvent.END_ARRAY:
+      onEndArray();
+      break;
+    case JsonEvent.FIELD_NAME:
+      onFieldName(parser.getCurrentString());
+      break;
+    case JsonEvent.VALUE_STRING:
+      onValue(parser.getCurrentString());
+      break;
+    case JsonEvent.VALUE_INT:
+      onValue(parser.getCurrentInt());
+      break;
+    case JsonEvent.VALUE_DOUBLE:
+      onValue(parser.getCurrentDouble());
+      break;
+    case JsonEvent.VALUE_TRUE:
+      onValue(true);
+      break;
+    case JsonEvent.VALUE_FALSE:
+      onValue(false);
+      break;
+    case JsonEvent.VALUE_NULL:
+      onValueNull();
+      break;
+    case JsonEvent.EOF:
+      break;
+    default:
+      throw new IllegalArgumentException("Unknown event: " + event);
+    }
+  }
+
+  /**
+   * @return the pretty JSON string
+   */
+  public String getResult() {
+    return result.toString();
   }
 }

--- a/src/test/java/de/undercouch/actson/PrettyPrinter.java
+++ b/src/test/java/de/undercouch/actson/PrettyPrinter.java
@@ -23,12 +23,11 @@
 
 package de.undercouch.actson;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import com.fasterxml.jackson.core.JsonGenerator;
 
-import de.undercouch.actson.JsonEvent;
-import de.undercouch.actson.JsonParser;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Demonstrates how you can use the {@link JsonParser} to pretty-print
@@ -42,176 +41,17 @@ public class PrettyPrinter {
    * Main method demonstrating how to use the pretty-printer
    * @param args program arguments
    */
-  public static void main(String[] args) {
-    byte[] json = "{\"name\":\"Elvis\"}".getBytes(StandardCharsets.UTF_8);
+  public static void main(String[] args) throws IOException {
+    byte[] json = "{\"name\":\"Elvis \\u266b\"}".getBytes(StandardCharsets.UTF_8);
 
     JsonParser parser = new JsonParser();
-    PrettyPrinter prettyPrinter = new PrettyPrinter();
 
-    int i = 0;
-    int event;
-    do {
-      while ((event = parser.nextEvent()) == JsonEvent.NEED_MORE_INPUT) {
-        i += parser.getFeeder().feed(json, i, json.length - i);
-        if (i == json.length) {
-          parser.getFeeder().done();
-        }
-      }
-      prettyPrinter.onEvent(event, parser);
-    } while (event != JsonEvent.EOF);
-
-    System.out.println(prettyPrinter.getResult());
+    final JsonGenerator generator = JsonHelper.defaultGenerator(new OutputStreamWriter(System.out));
+    JsonHelper.setPrettyPrint(generator);
+    JsonHelper.regenerateJson(json, parser, generator);
     // expected output:
     // {
-    //   "name: "Elvis"
+    //   "name: "Elvis ♫"
     // }
-  }
-
-  private static enum Type {
-    OBJECT, ARRAY
-  }
-
-  private StringBuilder result = new StringBuilder();
-  private Deque<Type> types = new ArrayDeque<>();
-  private Deque<Integer> elementCounts = new ArrayDeque<>();
-  private int level;
-
-  private void indent() {
-    for (int i = 0; i < level; ++i) {
-      result.append("  ");
-    }
-  }
-
-  private void onStartObject() {
-    onValue();
-    result.append("{\n");
-    level++;
-    indent();
-    elementCounts.push(0);
-    types.push(Type.OBJECT);
-  }
-
-  private void onEndObject() {
-    level--;
-    result.append("\n");
-    indent();
-    result.append("}");
-    elementCounts.pop();
-    types.pop();
-  }
-
-  private void onStartArray() {
-    onValue();
-    result.append("[\n");
-    level++;
-    indent();
-    elementCounts.push(0);
-    types.push(Type.ARRAY);
-  }
-
-  private void onEndArray() {
-    level--;
-    result.append("\n");
-    indent();
-    result.append("]");
-    elementCounts.pop();
-    types.pop();
-  }
-
-  private void onFieldName(String name) {
-    if (elementCounts.peek() > 0) {
-      result.append(",\n");
-      indent();
-    }
-    result.append("\"" + name + "\": ");
-    elementCounts.push(elementCounts.pop() + 1);
-  }
-
-  private void onValue() {
-    if (types.peek() == Type.ARRAY) {
-      if (elementCounts.peek() > 0) {
-        result.append(", ");
-      }
-      elementCounts.push(elementCounts.pop() + 1);
-    }
-  }
-
-  private void onValue(String value) {
-    onValue();
-    result.append("\"" + value + "\"");
-  }
-
-  private void onValue(int value) {
-    onValue();
-    result.append(value);
-  }
-
-  private void onValue(double value) {
-    onValue();
-    result.append(value);
-  }
-
-  private void onValue(boolean value) {
-    onValue();
-    result.append(value);
-  }
-
-  private void onValueNull() {
-    onValue();
-    result.append("null");
-  }
-
-  /**
-   * Call this method on every JSON event. It will generate pretty JSON text.
-   * @param event the JSON event returned by the parser
-   * @param parser the JSON parser
-   */
-  public void onEvent(int event, JsonParser parser) {
-    switch (event) {
-    case JsonEvent.START_OBJECT:
-      onStartObject();
-      break;
-    case JsonEvent.END_OBJECT:
-      onEndObject();
-      break;
-    case JsonEvent.START_ARRAY:
-      onStartArray();
-      break;
-    case JsonEvent.END_ARRAY:
-      onEndArray();
-      break;
-    case JsonEvent.FIELD_NAME:
-      onFieldName(parser.getCurrentString());
-      break;
-    case JsonEvent.VALUE_STRING:
-      onValue(parser.getCurrentString());
-      break;
-    case JsonEvent.VALUE_INT:
-      onValue(parser.getCurrentInt());
-      break;
-    case JsonEvent.VALUE_DOUBLE:
-      onValue(parser.getCurrentDouble());
-      break;
-    case JsonEvent.VALUE_TRUE:
-      onValue(true);
-      break;
-    case JsonEvent.VALUE_FALSE:
-      onValue(false);
-      break;
-    case JsonEvent.VALUE_NULL:
-      onValueNull();
-      break;
-    case JsonEvent.EOF:
-      break;
-    default:
-      throw new IllegalArgumentException("Unknown event: " + event);
-    }
-  }
-
-  /**
-   * @return the pretty JSON string
-   */
-  public String getResult() {
-    return result.toString();
   }
 }


### PR DESCRIPTION
Implementation of code point parser and single-char escapes, fixes #4 . Add code to handle "escape" events which previously just changed state. 

Use Jackson for pretty-printing JSON generation. To correctly render escaped sequences existing pretty printer should have been fixed but I decided not to fix it and use Jackson instead.

Extract common example/test code into separate class. Also I extracted feeding/event reading loop into separate class (`de.undercouch.actson.JsonHelper`). 

Use named constants for escape actions. To keep formatting of transition table since now actions take 3 positions. I'd use named constants for other actions but that probably should be in separate PR.

Results of tests https://github.com/nst/JSONTestSuite do not seem to be changed compared to master.