### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2.5.0
+      uses: actions/setup-java@v3
       with:
         java-version: 8
         distribution: zulu

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2.5.0

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation("org.assertj:assertj-core:3.22.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump jackson-databind from 2.13.1 to 2.13.2 (#23) @dependabot
* Bump actions/checkout from 2 to 3 (#22) @dependabot
* Bump actions/setup-java from 2.5.0 to 3 (#21) @dependabot
