### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     testImplementation 'commons-io:commons-io:2.11.0'
     testImplementation("org.assertj:assertj-core:3.23.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ tasks.withType(JavaCompile) {
 dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     testImplementation 'commons-io:commons-io:2.11.0'
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:3.23.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -4,7 +4,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 ext {
-    vertxVersion = '4.2.6'
+    vertxVersion = '4.3.1'
 }
 
 repositories {


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump assertj-core from 3.22.0 to 3.23.1 (#34) @dependabot
* Bump vertxVersion from 4.2.6 to 4.3.1 (#33) @dependabot
* Bump jackson-databind from 2.13.2.2 to 2.13.3 (#32) @dependabot
